### PR TITLE
Set Arproxy::Config#adapter from database.yml automatically

### DIFF
--- a/lib/arproxy/config.rb
+++ b/lib/arproxy/config.rb
@@ -5,6 +5,9 @@ module Arproxy
 
     def initialize
       @proxies = []
+      if defined?(Rails)
+        @adapter = Rails.application.config_for(:database)["adapter"]
+      end
     end
 
     def use(proxy_class, *options)

--- a/spec/arproxy/config_spec.rb
+++ b/spec/arproxy/config_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe Arproxy::Config do
+  describe "#adapter default value" do
+    subject { Arproxy::Config.new.adapter }
+
+    context "when Rails is defined" do
+      let(:rails) { Module.new }
+
+      around do |example|
+        Object.const_set("Rails", rails)
+        example.run
+        Object.send(:remove_const, "Rails")
+      end
+
+      before do
+        allow(rails).to receive_message_chain("application.config_for") { database_config }
+      end
+
+      context "when adapter is configured in database.yml" do
+        let(:database_config) { { "adapter" => "mysql2" } }
+
+        it { should == "mysql2" }
+      end
+
+      context "when adapter isn't configured in database.yml" do
+        let(:database_config) { {} }
+
+        it { should == nil }
+      end
+    end
+
+    context "when Rails isn't defined" do
+      it { should == nil }
+    end
+  end
+end


### PR DESCRIPTION
If we are using Rails, we can configure adapter automatically.

`Rails::Application#config_for` requires Rails >= 4.2.0.
https://github.com/rails/rails/blob/v4.2.0/railties/CHANGELOG.md
Note that Arproxy's dependency, activerecord >= 4.2.0, will always fulfill it.