### PR TITLE
Ruby warnings

### DIFF
--- a/lib/arproxy.rb
+++ b/lib/arproxy.rb
@@ -7,6 +7,7 @@ require "arproxy/error"
 require "arproxy/plugin"
 
 module Arproxy
+  @config = @enabled = nil
 
   module_function
   def clear_configuration


### PR DESCRIPTION
Here's a fix for some Ruby warnings that we see in our app.

Actually, we're still seeing another warning `warning: possibly useless use of :: in void context` [here](https://github.com/cookpad/arproxy/blob/3ff68fef2be1cc7c3dbaf6c1a92076b143e578f9/lib/arproxy.rb#L32), but I still can't come up with a great fix without breaking the intention of the code...