### PR TITLE
Stop using `::` in void context

### DIFF
--- a/lib/arproxy.rb
+++ b/lib/arproxy.rb
@@ -1,5 +1,4 @@
 require "logger"
-require "active_record"
 require "arproxy/base"
 require "arproxy/config"
 require "arproxy/proxy_chain"
@@ -28,9 +27,6 @@ module Arproxy
     unless @config
       raise Arproxy::Error, "Arproxy should be configured"
     end
-
-    # for lazy loading
-    ::ActiveRecord::Base
 
     @proxy_chain = ProxyChain.new @config
     @proxy_chain.enable!

--- a/lib/arproxy/config.rb
+++ b/lib/arproxy/config.rb
@@ -1,3 +1,6 @@
+require "active_record"
+require "active_record/base"
+
 module Arproxy
   class Config
     attr_accessor :adapter, :logger


### PR DESCRIPTION
From #12:

> Actually, we're still seeing another warning `warning: possibly useless use of :: in void context` [here](https://github.com/cookpad/arproxy/blob/3ff68fef2be1cc7c3dbaf6c1a92076b143e578f9/lib/arproxy.rb#L32), but I still can't come up with a great fix without breaking the intention of the code...