### PR TITLE
Not to load ActiveRecord::Base on gem load timing

### DIFF
--- a/lib/arproxy/config.rb
+++ b/lib/arproxy/config.rb
@@ -1,5 +1,4 @@
 require "active_record"
-require "active_record/base"
 
 module Arproxy
   class Config

--- a/lib/arproxy/config.rb
+++ b/lib/arproxy/config.rb
@@ -23,6 +23,8 @@ module Arproxy
     end
 
     def adapter_class
+      require 'active_record/base'
+
       raise Arproxy::Error, "config.adapter must be set" unless @adapter
       case @adapter
       when String, Symbol


### PR DESCRIPTION
## What happened

After this commit https://github.com/cookpad/arproxy/commit/21ec71576925f051a57c4aa48f5977e0b4a4ab78, `ActiveRecord::Base` class is loaded on `arproxy` gem load timing.
(In common Rails applications, it may mean that `AR::Base` is loaded on `config/application.rb`)

It causes an error like this https://github.com/rails/rails/issues/27844#issuecomment-276275290.

## Idea

I think `AR::Base` class is loaded after files under `config/initializers` are loaded ideally, because some mechanisms Rails uses are based on that loading order.

For example, `ActiveSupport::LazyLoadHooks.on_load(:active_record)` is expected to be used on `config/initializers` and `ActiveSupport::LazyLoadHooks.run_load_hooks(:active_record)` is called on `AR::Base` class.

https://api.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html
https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/base.rb#L328

## Conclusion

I wrote a patch to require `active_record/base` just before it is needed.

I want some opinions from maintainers, thank you.