### PR TITLE
Support config.adapter = 'sqlite3'

### DIFF
--- a/lib/arproxy/config.rb
+++ b/lib/arproxy/config.rb
@@ -28,6 +28,9 @@ module Arproxy
       case @adapter
       when String, Symbol
         camelized_adapter_name = @adapter.to_s.split("_").map(&:capitalize).join
+        if camelized_adapter_name == "Sqlite3"
+          camelized_adapter_name = "SQLite3"
+        end
         eval "::ActiveRecord::ConnectionAdapters::#{camelized_adapter_name}Adapter"
       when Class
         @adapter

--- a/spec/arproxy/config_spec.rb
+++ b/spec/arproxy/config_spec.rb
@@ -34,4 +34,35 @@ describe Arproxy::Config do
       it { should == nil }
     end
   end
+
+  describe "#adapter_class" do
+    subject { config.adapter_class }
+    let(:config) { Arproxy::Config.new }
+
+    before do
+      config.adapter = adapter
+    end
+
+    context "when adapter is configured as 'mysql2'" do
+      let(:adapter) { "mysql2" }
+      let(:mysql2_class) { Class.new }
+
+      before do
+        stub_const("ActiveRecord::ConnectionAdapters::Mysql2Adapter", mysql2_class)
+      end
+
+      it { should == mysql2_class }
+    end
+
+    context "when adapter is configured as 'sqlite3'" do
+      let(:adapter) { "sqlite3" }
+      let(:sqlite3_class) { Class.new }
+
+      before do
+        stub_const("ActiveRecord::ConnectionAdapters::SQLite3Adapter", sqlite3_class)
+      end
+
+      it { should == sqlite3_class }
+    end
+  end
 end


### PR DESCRIPTION
Currently setting config.adapter = 'sqlite3' fails because this module tries to access global constant ActiveRecord::ConnectionAdapters::**Sqlite3Adapter**, which simply does not exist.

```ruby
require 'arproxy'
Arproxy.configure do |config|
  config.adapter = "sqlite3"
end
Arproxy.enable!
```

```
Traceback (most recent call last):
	5: from temp.rb:5:in `<main>'
	4: from /Users/koki-takahashi/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/arproxy-0.2.5/lib/arproxy.rb:32:in `enable!'
	3: from /Users/koki-takahashi/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/arproxy-0.2.5/lib/arproxy/proxy_chain.rb:31:in `enable!'
	2: from /Users/koki-takahashi/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/arproxy-0.2.5/lib/arproxy/config.rb:31:in `adapter_class'
	1: from /Users/koki-takahashi/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/arproxy-0.2.5/lib/arproxy/config.rb:31:in `eval'
(eval):1:in `adapter_class': uninitialized constant ActiveRecord::ConnectionAdapters::Sqlite3Adapter (NameError)
```

The spelling should be [**SQLite3Adapter**](https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb). I fixed it to match the correct case.