### PR TITLE
Support config.adapter = 'sqlserver'

### DIFF
--- a/lib/arproxy/config.rb
+++ b/lib/arproxy/config.rb
@@ -27,15 +27,26 @@ module Arproxy
       raise Arproxy::Error, "config.adapter must be set" unless @adapter
       case @adapter
       when String, Symbol
-        camelized_adapter_name = @adapter.to_s.split("_").map(&:capitalize).join
-        if camelized_adapter_name == "Sqlite3"
-          camelized_adapter_name = "SQLite3"
-        end
         eval "::ActiveRecord::ConnectionAdapters::#{camelized_adapter_name}Adapter"
       when Class
         @adapter
       else
         raise Arproxy::Error, "unexpected config.adapter: #{@adapter}"
+      end
+    end
+
+    private
+
+    def camelized_adapter_name
+      adapter_name = @adapter.to_s.split("_").map(&:capitalize).join
+
+      case adapter_name
+      when 'Sqlite3'
+        'SQLite3'
+      when 'Sqlserver'
+        'SQLServer'
+      else
+        adapter_name
       end
     end
   end

--- a/spec/arproxy/config_spec.rb
+++ b/spec/arproxy/config_spec.rb
@@ -64,5 +64,16 @@ describe Arproxy::Config do
 
       it { should == sqlite3_class }
     end
+
+    context "when adapter is configured as 'sqlserver'" do
+      let(:adapter) { "sqlserver" }
+      let(:sqlserver_class) { Class.new }
+
+      before do
+        stub_const("ActiveRecord::ConnectionAdapters::SQLServerAdapter", sqlserver_class)
+      end
+
+      it { should == sqlserver_class }
+    end
   end
 end


### PR DESCRIPTION
Currently, this gem does not support activerecord-sqlserver-adapter.

```
require 'arproxy'
Arproxy.configure do |config|
  config.adapter = "sqlserver"
end
Arproxy.enable!
```

```
8: from /Users/takanamito/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/arproxy-0.2.6/lib/arproxy.rb:32:in `enable!'
7: from /Users/takanamito/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/arproxy-0.2.6/lib/arproxy/proxy_chain.rb:31:in `enable!'
6: from /Users/takanamito/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/arproxy-0.2.6/lib/arproxy/config.rb:34:in `adapter_class'
5: from /Users/takanamito/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/arproxy-0.2.6/lib/arproxy/config.rb:34:in `eval'
4: from (eval):1:in `adapter_class'
3: from /Users/takanamito/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/active_support.rb:59:in `load_missing_constant'
2: from /Users/takanamito/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/active_support.rb:80:in `rescue in load_missing_constant'
1: from /Users/takanamito/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/active_support.rb:9:in `without_bootsnap_cache'
/Users/takanamito/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/active_support.rb:80:in `block in load_missing_constant': uninitialized constant ActiveRecord::ConnectionAdapters::SqlserverAdapter (NameError)
```

The adapter class spelling should be SQLServer. I fixed it to match the correct case.