### PR TITLE
CI against ruby 2.7 and Rails 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
 gemfile:
   - gemfiles/ar_4.2.gemfile
   - gemfiles/ar_5.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,12 @@ gemfile:
   - gemfiles/ar_6.0.gemfile
 matrix:
   allow_failures:
-    - gemfile: gemfiles/ar_6.0.gemfile
+    # Rails 6 requires Ruby 2.5 or newer. ref: https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#ruby-versions
     - rvm: 2.4
+      gemfile: gemfiles/ar_6.0.gemfile
+    # BigDecimal 2.0 does not support `BigDecimal.new`. ref: https://github.com/ruby/bigdecimal#which-version-should-you-select
+    - rvm: 2.7
+      gemfile: gemfiles/ar_4.2.gemfile
   fast_finish: true
 before_install:
   - gem update --system

--- a/gemfiles/ar_6.0.gemfile
+++ b/gemfiles/ar_6.0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.0.0.beta"
+gem "activerecord", "~> 6.0.0"
 
 gemspec path: "../"


### PR DESCRIPTION
CI update.

- CI against Ruby 2.7
- CI against Rails 6.0
- Arrange `allow_failures` config