### PR TITLE
Add PostgreSQL support

### DIFF
--- a/lib/arproxy/config.rb
+++ b/lib/arproxy/config.rb
@@ -45,7 +45,7 @@ module Arproxy
         'SQLite3'
       when 'Sqlserver'
         'SQLServer'
-      when 'postgresql'
+      when 'Postgresql'
         'PostgreSQL'
       else
         adapter_name

--- a/lib/arproxy/config.rb
+++ b/lib/arproxy/config.rb
@@ -45,6 +45,8 @@ module Arproxy
         'SQLite3'
       when 'Sqlserver'
         'SQLServer'
+      when 'postgresql'
+        'PostgreSQL'
       else
         adapter_name
       end

--- a/spec/arproxy/config_spec.rb
+++ b/spec/arproxy/config_spec.rb
@@ -75,5 +75,16 @@ describe Arproxy::Config do
 
       it { should == sqlserver_class }
     end
+
+    context "when adapter is configured as 'postgresql'" do
+      let(:adapter) { "postgresql" }
+      let(:postgresql_class) { Class.new }
+
+      before do
+        stub_const("ActiveRecord::ConnectionAdapters::PostgreSQLAdapter", postgresql_class)
+      end
+
+      it { should == postgresql_class }
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for the `postgresql` adapter
```
	 4: from /Users/jhnvz/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/arproxy-0.2.7/lib/arproxy.rb:32:in `enable!'
	 3: from /Users/jhnvz/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/arproxy-0.2.7/lib/arproxy/proxy_chain.rb:31:in `enable!'
	 2: from /Users/jhnvz/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/arproxy-0.2.7/lib/arproxy/config.rb:30:in `adapter_class'
	 1: from /Users/jhnvz/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/arproxy-0.2.7/lib/arproxy/config.rb:30:in `eval'
(eval):1:in `adapter_class': uninitialized constant ActiveRecord::ConnectionAdapters::PostgresqlAdapter (NameError)
```