### PR TITLE
Fix ArgumentError on activerecord 7.0

### DIFF
--- a/lib/arproxy/base.rb
+++ b/lib/arproxy/base.rb
@@ -2,8 +2,8 @@ module Arproxy
   class Base
     attr_accessor :proxy_chain, :next_proxy
 
-    def execute(sql, name=nil)
-      next_proxy.execute sql, name
+    def execute(sql, name=nil, **kwargs)
+      next_proxy.execute sql, name, **kwargs
     end
   end
 end

--- a/lib/arproxy/chain_tail.rb
+++ b/lib/arproxy/chain_tail.rb
@@ -4,8 +4,8 @@ module Arproxy
       self.proxy_chain = proxy_chain
     end
 
-    def execute(sql, name=nil)
-      self.proxy_chain.connection.execute_without_arproxy sql, name
+    def execute(sql, name=nil, **kwargs)
+      self.proxy_chain.connection.execute_without_arproxy sql, name, **kwargs
     end
   end
 end

--- a/lib/arproxy/proxy_chain.rb
+++ b/lib/arproxy/proxy_chain.rb
@@ -29,9 +29,9 @@ module Arproxy
 
     def enable!
       @config.adapter_class.class_eval do
-        def execute_with_arproxy(sql, name=nil)
+        def execute_with_arproxy(sql, name=nil, **kwargs)
           ::Arproxy.proxy_chain.connection = self
-          ::Arproxy.proxy_chain.head.execute sql, name
+          ::Arproxy.proxy_chain.head.execute sql, name, **kwargs
         end
         alias_method :execute_without_arproxy, :execute
         alias_method :execute, :execute_with_arproxy


### PR DESCRIPTION
The `#execute` method may have keyword-arguments, particular at MySQL adapter since activerecord 7.0.0.
See also: https://github.com/rails/rails/commit/7fc174aadaefc2c0a8a6b7c8a7599dd9ca04811f

Resolve https://github.com/cookpad/arproxy/issues/20.