### PR TITLE
Avoid eager loading `ActiveRecord::Base`

### DIFF
--- a/arproxy.gemspec
+++ b/arproxy.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths     = ["lib"]
 
   spec.add_dependency 'activerecord', '>= 4.2.0'
+  spec.add_dependency 'activesupport', '>= 4.2.0'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 12.3.3"

--- a/lib/arproxy.rb
+++ b/lib/arproxy.rb
@@ -4,6 +4,8 @@ require "arproxy/config"
 require "arproxy/proxy_chain"
 require "arproxy/error"
 require "arproxy/plugin"
+require "active_record"
+require "active_support"
 
 module Arproxy
   @config = @enabled = nil
@@ -28,8 +30,15 @@ module Arproxy
       raise Arproxy::Error, "Arproxy should be configured"
     end
 
-    @proxy_chain = ProxyChain.new @config
-    @proxy_chain.enable!
+    if ActiveRecord.autoload? :Base
+      ActiveSupport.on_load(:active_record, yield: true) do
+        @proxy_chain = ProxyChain.new @config
+        @proxy_chain.enable!
+      end
+    else
+      @proxy_chain = ProxyChain.new @config
+      @proxy_chain.enable!
+    end
 
     @enabled = true
   end

--- a/lib/arproxy/config.rb
+++ b/lib/arproxy/config.rb
@@ -1,5 +1,4 @@
 require "active_record"
-require "active_record/base"
 
 module Arproxy
   class Config


### PR DESCRIPTION
## Problem

When Arproxy is loaded by specifying `Gemfile`, `require "active_record/base"` is called and `ActiveRecord::Base` is loaded.
Just when `Rails.application.config.active_record.xxx` are copied to `ActiveRecord::Base.xxx`.
So, `config/initializers/new_framework_defaults_x_x.rb` does not work well.

## This PR's solution

Arproxy avoid eager loading `ActiveRecord::Base`, and defer `proxy_chain.enable!` call until `ActiveRecord::Base` is loaded.

## Other solution

I thought following solution, but it is a bit tricky. I think this PR's solution is easier for gem users.

``` ruby
# Gemfile
gem "arproxy", require: false
```
``` ruby
# config/initializers/arproxy.rb
Rails.configuration.after_initialize do # or on_prepare
  require "arproxy"

  # setup arproxy...
end
``` 