### PR TITLE
Update supported ruby and rails versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,23 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
-        gemfile: ['ar_4.2', 'ar_5.2', 'ar_6.1', 'ar_7.0']
-        exclude:
-          - gemfile: ar_4.2
-            ruby-version: 2.7
-          - gemfile: ar_4.2
-            ruby-version: 3.0
-          - gemfile: ar_7.0
-            ruby-version: 2.6
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        gemfile: ['ar_6.1', 'ar_7.0']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,3 @@
-appraise 'ar-4.2' do
-  gem 'activerecord', '~> 4.2.0'
-end
-
-appraise 'ar-5.2' do
-  gem 'activerecord', '~> 5.2.0'
-end
-
 appraise 'ar-6.1' do
   gem 'activerecord', '~> 6.1.0'
 end

--- a/README.md
+++ b/README.md
@@ -134,4 +134,4 @@ Then `"User Load"` is the `name`.
 Arproxy is released under the MIT license:
 * www.opensource.org/licenses/MIT
 
-Copyright (c) 2021 Issei Naruta
+Copyright (c) 2023 Issei Naruta


### PR DESCRIPTION
Update supported versions:

- Rails
  - remove: 4.2, 5.2
- Ruby
  - remove: 2.6
  - add: 3.1, 3.2