### PR TITLE
Support ActiveRecored 7.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,19 @@ Write your proxy and its configurations in Rails' config/initializers:
 
 ```ruby
 class QueryTracer < Arproxy::Base
+  # for your ActiveRecored version <= 7.0.x
   def execute(sql, name=nil)
     Rails.logger.debug sql
     Rails.logger.debug caller(1).join("\n")
     super(sql, name)
+  end
+
+  # for your ActiveRecored version >= 7.1.x
+  private
+  def raw_execute(sql, name, **kwargs)
+    Rails.logger.debug sql
+    Rails.logger.debug caller(1).join("\n")
+    super(sql, name, **kwargs)
   end
 end
 

--- a/lib/arproxy/base.rb
+++ b/lib/arproxy/base.rb
@@ -5,5 +5,10 @@ module Arproxy
     def execute(sql, name=nil, **kwargs)
       next_proxy.execute sql, name, **kwargs
     end
+
+    private
+    def raw_execute(sql, name, **kwargs)
+      next_proxy.send :raw_execute, sql, name, **kwargs
+    end
   end
 end

--- a/lib/arproxy/chain_tail.rb
+++ b/lib/arproxy/chain_tail.rb
@@ -7,5 +7,10 @@ module Arproxy
     def execute(sql, name=nil, **kwargs)
       self.proxy_chain.connection.execute_without_arproxy sql, name, **kwargs
     end
+
+    private
+    def raw_execute(sql, name, **kwargs)
+      self.proxy_chain.connection.send :raw_execute_without_arproxy, sql, name, **kwargs
+    end
   end
 end

--- a/spec/arproxy/config_spec.rb
+++ b/spec/arproxy/config_spec.rb
@@ -54,6 +54,17 @@ describe Arproxy::Config do
       it { should == mysql2_class }
     end
 
+    context "when adapter is configured as 'trilogy'" do
+      let(:adapter) { "trilogy" }
+      let(:trilogy_class) { Class.new }
+
+      before do
+        stub_const("ActiveRecord::ConnectionAdapters::TrilogyAdapter", trilogy_class)
+      end
+
+      it { should == trilogy_class }
+    end
+
     context "when adapter is configured as 'sqlite3'" do
       let(:adapter) { "sqlite3" }
       let(:sqlite3_class) { Class.new }

--- a/spec/arproxy/plugin/test.rb
+++ b/spec/arproxy/plugin/test.rb
@@ -9,5 +9,10 @@ module Arproxy::Plugin
     def execute(sql, name=nil)
       {:sql => "#{sql}_PLUGIN", :name => "#{name}_PLUGIN", :options => @options}
     end
+
+    private
+    def raw_execute(sql, name, **kwargs)
+      {:sql => "#{sql}_PLUGIN", :name => "#{name}_PLUGIN", :options => @options}
+    end
   end
 end

--- a/spec/arproxy_spec.rb
+++ b/spec/arproxy_spec.rb
@@ -9,6 +9,11 @@ describe Arproxy do
     def execute(sql, name)
       super "#{sql}_A", "#{name}_A"
     end
+
+    private
+    def raw_execute(sql, name, **kwargs)
+      super "#{sql}_C", "#{name}_C"
+    end
   end
 
   class ProxyB < Arproxy::Base
@@ -19,6 +24,11 @@ describe Arproxy do
     def execute(sql, name)
       super "#{sql}_B#{@opt}", "#{name}_B#{@opt}"
     end
+
+    private
+    def raw_execute(sql, name, **kwargs)
+      super "#{sql}_D#{@opt}", "#{name}_D#{@opt}"
+    end
   end
 
   module ::ActiveRecord
@@ -27,146 +37,278 @@ describe Arproxy do
         def execute(sql, name = nil)
           {:sql => sql, :name => name}
         end
+
+        private
+        def raw_execute(sql, name, async: false, materialize_transactions: true)
+          {:sql => sql, :name => name}
+        end
       end
     end
   end
 
   let(:connection) { ::ActiveRecord::ConnectionAdapters::DummyAdapter.new }
-  subject { connection.execute "SQL", "NAME" }
   after(:each) do
     Arproxy.disable!
   end
 
-  context "with a proxy" do
-    before do
-      Arproxy.clear_configuration
-      Arproxy.configure do |config|
-        config.adapter = "dummy"
-        config.use ProxyA
-      end
-      Arproxy.enable!
-    end
+  describe "#execute" do
+    subject { connection.execute "SQL", "NAME" }
 
-    it { should == {:sql => "SQL_A", :name => "NAME_A"} }
-  end
-
-  context "with 2 proxies" do
-    before do
-      Arproxy.clear_configuration
-      Arproxy.configure do |config|
-        config.adapter = "dummy"
-        config.use ProxyA
-        config.use ProxyB
-      end
-      Arproxy.enable!
-    end
-
-    it { should == {:sql => "SQL_A_B", :name => "NAME_A_B"} }
-  end
-
-  context "with 2 proxies which have an option" do
-    before do
-      Arproxy.clear_configuration
-      Arproxy.configure do |config|
-        config.adapter = "dummy"
-        config.use ProxyA
-        config.use ProxyB, 1
-      end
-      Arproxy.enable!
-    end
-
-    it { should == {:sql => "SQL_A_B1", :name => "NAME_A_B1"} }
-  end
-
-  context do
-    before do
-      Arproxy.clear_configuration
-      Arproxy.configure do |config|
-        config.adapter = "dummy"
-        config.use ProxyA
-      end
-    end
-
-    context "enable -> disable" do
+    context "with a proxy" do
       before do
-        Arproxy.enable!
-        Arproxy.disable!
-      end
-      it { should == {:sql => "SQL", :name => "NAME"} }
-    end
-
-    context "enable -> enable" do
-      before do
-        Arproxy.enable!
-        Arproxy.enable!
-      end
-      it { should == {:sql => "SQL_A", :name => "NAME_A"} }
-    end
-
-    context "enable -> disable -> disable" do
-      before do
-        Arproxy.enable!
-        Arproxy.disable!
-        Arproxy.disable!
-      end
-      it { should == {:sql => "SQL", :name => "NAME"} }
-    end
-
-    context "enable -> disable -> enable" do
-      before do
-        Arproxy.enable!
-        Arproxy.disable!
-        Arproxy.enable!
-      end
-      it { should == {:sql => "SQL_A", :name => "NAME_A"} }
-    end
-
-    context "re-configure" do
-      before do
+        Arproxy.clear_configuration
         Arproxy.configure do |config|
+          config.adapter = "dummy"
+          config.use ProxyA
+        end
+        Arproxy.enable!
+      end
+
+      it { should == {:sql => "SQL_A", :name => "NAME_A"} }
+    end
+
+    context "with 2 proxies" do
+      before do
+        Arproxy.clear_configuration
+        Arproxy.configure do |config|
+          config.adapter = "dummy"
+          config.use ProxyA
           config.use ProxyB
         end
         Arproxy.enable!
       end
+
       it { should == {:sql => "SQL_A_B", :name => "NAME_A_B"} }
     end
+
+    context "with 2 proxies which have an option" do
+      before do
+        Arproxy.clear_configuration
+        Arproxy.configure do |config|
+          config.adapter = "dummy"
+          config.use ProxyA
+          config.use ProxyB, 1
+        end
+        Arproxy.enable!
+      end
+
+      it { should == {:sql => "SQL_A_B1", :name => "NAME_A_B1"} }
+    end
+
+    context do
+      before do
+        Arproxy.clear_configuration
+        Arproxy.configure do |config|
+          config.adapter = "dummy"
+          config.use ProxyA
+        end
+      end
+
+      context "enable -> disable" do
+        before do
+          Arproxy.enable!
+          Arproxy.disable!
+        end
+        it { should == {:sql => "SQL", :name => "NAME"} }
+      end
+
+      context "enable -> enable" do
+        before do
+          Arproxy.enable!
+          Arproxy.enable!
+        end
+        it { should == {:sql => "SQL_A", :name => "NAME_A"} }
+      end
+
+      context "enable -> disable -> disable" do
+        before do
+          Arproxy.enable!
+          Arproxy.disable!
+          Arproxy.disable!
+        end
+        it { should == {:sql => "SQL", :name => "NAME"} }
+      end
+
+      context "enable -> disable -> enable" do
+        before do
+          Arproxy.enable!
+          Arproxy.disable!
+          Arproxy.enable!
+        end
+        it { should == {:sql => "SQL_A", :name => "NAME_A"} }
+      end
+
+      context "re-configure" do
+        before do
+          Arproxy.configure do |config|
+            config.use ProxyB
+          end
+          Arproxy.enable!
+        end
+        it { should == {:sql => "SQL_A_B", :name => "NAME_A_B"} }
+      end
+    end
+
+    context "use a plug-in" do
+      before do
+        Arproxy.clear_configuration
+        Arproxy.configure do |config|
+          config.adapter = "dummy"
+          config.plugin :test, :option_a, :option_b
+        end
+        Arproxy.enable!
+      end
+
+      it { should == {:sql => "SQL_PLUGIN", :name => "NAME_PLUGIN", :options => [:option_a, :option_b]} }
+    end
+
+    context "ProxyChain thread-safety" do
+      class ProxyWithConnectionId < Arproxy::Base
+        def execute(sql, name)
+          sleep 0.1
+          super "#{sql} /* connection_id=#{self.proxy_chain.connection.object_id} */", name
+        end
+      end
+
+      before do
+        Arproxy.clear_configuration
+        Arproxy.configure do |config|
+          config.adapter = "dummy"
+          config.use ProxyWithConnectionId
+        end
+        Arproxy.enable!
+      end
+
+      context "with two threads" do
+        let!(:thr1) { Thread.new { connection.dup.execute 'SELECT 1' } }
+        let!(:thr2) { Thread.new { connection.dup.execute 'SELECT 1' } }
+
+        it { expect(thr1.value).not_to eq(thr2.value) }
+      end
+    end
   end
 
-  context "use a plug-in" do
-    before do
-      Arproxy.clear_configuration
-      Arproxy.configure do |config|
-        config.adapter = "dummy"
-        config.plugin :test, :option_a, :option_b
+  describe "#raw_execute" do
+    subject { connection.send :raw_execute, "SQL", "NAME" }
+
+    context "with a proxy" do
+      before do
+        Arproxy.clear_configuration
+        Arproxy.configure do |config|
+          config.adapter = "dummy"
+          config.use ProxyA
+        end
+        Arproxy.enable!
       end
-      Arproxy.enable!
+
+      it { should == {:sql => "SQL_C", :name => "NAME_C"} }
     end
 
-    it { should == {:sql => "SQL_PLUGIN", :name => "NAME_PLUGIN", :options => [:option_a, :option_b]} }
-  end
+    context "with 2 proxies which have an option" do
+      before do
+        Arproxy.clear_configuration
+        Arproxy.configure do |config|
+          config.adapter = "dummy"
+          config.use ProxyA
+          config.use ProxyB, 1
+        end
+        Arproxy.enable!
+      end
 
-  context "ProxyChain thread-safety" do
-    class ProxyWithConnectionId < Arproxy::Base
-      def execute(sql, name)
-        sleep 0.1
-        super "#{sql} /* connection_id=#{self.proxy_chain.connection.object_id} */", name
+      it { should == {:sql => "SQL_C_D1", :name => "NAME_C_D1"} }
+    end
+
+    context do
+      before do
+        Arproxy.clear_configuration
+        Arproxy.configure do |config|
+          config.adapter = "dummy"
+          config.use ProxyA
+        end
+      end
+
+      context "enable -> disable" do
+        before do
+          Arproxy.enable!
+          Arproxy.disable!
+        end
+        it { should == {:sql => "SQL", :name => "NAME"} }
+      end
+
+      context "enable -> enable" do
+        before do
+          Arproxy.enable!
+          Arproxy.enable!
+        end
+        it { should == {:sql => "SQL_C", :name => "NAME_C"} }
+      end
+
+      context "enable -> disable -> disable" do
+        before do
+          Arproxy.enable!
+          Arproxy.disable!
+          Arproxy.disable!
+        end
+        it { should == {:sql => "SQL", :name => "NAME"} }
+      end
+
+      context "enable -> disable -> enable" do
+        before do
+          Arproxy.enable!
+          Arproxy.disable!
+          Arproxy.enable!
+        end
+        it { should == {:sql => "SQL_C", :name => "NAME_C"} }
+      end
+
+      context "re-configure" do
+        before do
+          Arproxy.configure do |config|
+            config.use ProxyB
+          end
+          Arproxy.enable!
+        end
+        it { should == {:sql => "SQL_C_D", :name => "NAME_C_D"} }
       end
     end
 
-    before do
-      Arproxy.clear_configuration
-      Arproxy.configure do |config|
-        config.adapter = "dummy"
-        config.use ProxyWithConnectionId
+    context "use a plug-in" do
+      before do
+        Arproxy.clear_configuration
+        Arproxy.configure do |config|
+          config.adapter = "dummy"
+          config.plugin :test, :option_a, :option_b
+        end
+        Arproxy.enable!
       end
-      Arproxy.enable!
+
+      it { should == {:sql => "SQL_PLUGIN", :name => "NAME_PLUGIN", :options => [:option_a, :option_b]} }
     end
 
-    context "with two threads" do
-      let!(:thr1) { Thread.new { connection.dup.execute 'SELECT 1' } }
-      let!(:thr2) { Thread.new { connection.dup.execute 'SELECT 1' } }
+    context "ProxyChain thread-safety" do
+      class ProxyWithConnectionId < Arproxy::Base
+        private
+        def raw_execute(sql, name, **kwargs)
+          sleep 0.1
+          super "#{sql} /* connection_id=#{self.proxy_chain.connection.object_id} */", name, **kwargs
+        end
+      end
 
-      it { expect(thr1.value).not_to eq(thr2.value) }
+      before do
+        Arproxy.clear_configuration
+        Arproxy.configure do |config|
+          config.adapter = "dummy"
+          config.use ProxyWithConnectionId
+        end
+        Arproxy.enable!
+      end
+
+      context "with two threads" do
+        let!(:thr1) { Thread.new { connection.dup.execute 'SELECT 1' } }
+        let!(:thr2) { Thread.new { connection.dup.execute 'SELECT 1' } }
+
+        it { expect(thr1.value).not_to eq(thr2.value) }
+      end
     end
   end
 end


### PR DESCRIPTION
Since ActiveRecored 7.1, using `#execute` no longer works as intended.

ref
https://github.com/rails/rails/commit/63c0d6b31bcd0fc33745ec6fd278b2d1aab9be54#diff-0b861bb8bc857373d0f0280779eb119e2937ee0edd1cc 3497292c7d14e909591
#26

Instead, I have made a change to use `#raw_execute`.

Since `#raw_execute` is a private method, I'm not too keen on it, but if you have a better implementation, please give me feedback.


Currently, this Patch is not in production quality, so please use it at your own risk. Also, feedback is welcome.
